### PR TITLE
fix number format parsing when system language is not English

### DIFF
--- a/estateguru.lua
+++ b/estateguru.lua
@@ -124,6 +124,9 @@ end
 function InitializeSession2(protocol, bankCode, step, credentials, interactive)
     if step == 1 then
         connection = Connection()
+        -- Enforce english language
+        connection:setCookie("lng=en-US; path=/")
+        connection:setCookie("portal.lang=en; path=/")
         return authenticatePass(credentials[1], credentials[2])
     elseif step == 2 then
         return authenticate2FA(credentialCache.username, credentialCache.password, credentials[1])


### PR DESCRIPTION
When the System Language is something different than English the Estateguru Portal might use a different number format which causes MoneyMoney to display an incorrect balance.

This pull request adds two cookies that ensure that the EstateGuru portal is always in the English language (US).

Refers #9 