### PR TITLE
always request en-gb version of the portal

### DIFF
--- a/estateguru.lua
+++ b/estateguru.lua
@@ -127,6 +127,7 @@ function InitializeSession2(protocol, bankCode, step, credentials, interactive)
         -- Enforce english language
         connection:setCookie("lng=en-US; path=/")
         connection:setCookie("portal.lang=en; path=/")
+        connection.language = "en-gb"
         return authenticatePass(credentials[1], credentials[2])
     elseif step == 2 then
         return authenticate2FA(credentialCache.username, credentialCache.password, credentials[1])


### PR DESCRIPTION
Always request en-gb version of EstateGuru portal to fix numbering issues.

Refers #9 