### PR TITLE
Add support for Google Authenticator

### DIFF
--- a/estateguru.lua
+++ b/estateguru.lua
@@ -139,6 +139,7 @@ function InitializeSession2(protocol, bankCode, step, credentials, interactive)
         -- Enforce english language
         connection:setCookie("lng=en-US; path=/")
         connection:setCookie("portal.lang=en; path=/")
+        connection.language = "en-gb"
         return authenticatePass(credentials[1], credentials[2])
     elseif step == 2 then
         return authenticate2FA(credentialCache.username, credentialCache.password, credentials[1])


### PR DESCRIPTION
When Google Authenticator is configured the login does not work anymore, even when SMS Authentication is enabled.

This pull requests adds support for Google Authenticator OTP and will automatically fallback to SMS Authentication when OTP is not configured.